### PR TITLE
Attempt fix

### DIFF
--- a/rsl_rl/algorithms/bima_ppo.py
+++ b/rsl_rl/algorithms/bima_ppo.py
@@ -48,7 +48,7 @@ class BimaPPO:
                  value_loss_coef=1.0,
                  entropy_coef=0.0,
                  learning_rate=1e-3,
-                 max_grad_norm=1.0,
+                 max_grad_norm=2.0,
                  use_clipped_value_loss=True,
                  schedule="fixed",
                  desired_kl=0.01,

--- a/rsl_rl/attention/encoders.py
+++ b/rsl_rl/attention/encoders.py
@@ -128,7 +128,7 @@ class EncoderAttention3(nn.Module):
 
 class EncoderAttention4(nn.Module):
 
-  def __init__(self, num_ego_obs, num_ado_obs , hidden_dims, output_dim, numteams, teamsize, activation, device='cpu'):
+  def __init__(self, num_ego_obs, num_ado_obs , hidden_dims, output_dim, numteams, teamsize, activation):
 
         super(EncoderAttention4, self).__init__()
 
@@ -137,16 +137,18 @@ class EncoderAttention4(nn.Module):
         self.num_ado_obs = num_ado_obs
         self.teamsize = teamsize
 
-        self.team_ids = [team_id for team_id in range(numteams) for _ in range(teamsize)]
-        self.team_ids = torch.tensor(self.team_ids).to(device)
-
+        self.team_ids_list = [team_id for team_id in range(numteams) for _ in range(teamsize)]
+        team_ids = torch.tensor(self.team_ids_list, dtype=torch.float)
+        self.register_buffer('team_ids', team_ids)
+        # self.team_ids = self.team_ids.detach()
         # Parameters
         attention_heads = 4
         # hidden_dim = 32
         self.attend_dim = hidden_dims[-1] // attention_heads
 
-        self.attention_weights = torch.zeros((attention_heads, self.num_agents-1)).to(device)
-
+        attention_weights = torch.zeros((attention_heads, self.num_agents-1))
+        self.register_buffer('attention_weights', attention_weights)
+        #if want it to get grad updates, set as torch.nn.Parameter
 
         # EGO encoder
         ego_encoder_layers = []

--- a/rsl_rl/modules/bilevel_actor_critic_attention.py
+++ b/rsl_rl/modules/bilevel_actor_critic_attention.py
@@ -36,7 +36,7 @@ from torch.distributions import Normal
 from torch.distributions import OneHotCategorical, TransformedDistribution, AffineTransform
 from torch.nn.modules import rnn
 import torch.nn.functional as F
-
+from rsl_rl.attention.encoders import EncoderAttention1,EncoderAttention2, EncoderAttention3, EncoderAttention4 
 from rsl_rl.utils import TruncatedNormal, SquashedNormal
 
 # from rsl_rl.modules.attention.encoders import EncoderAttention4
@@ -80,6 +80,7 @@ class BilevelActorCriticAttention(nn.Module):
                         init_noise_std=1.0,
                         critic_output_dim=1,
                         std_per_dim=False,
+                        encoder_type = 'attention4',
                         **kwargs):
         if kwargs:
             print("ActorCritic.__init__ got unexpected arguments, which will be ignored: " + str([key for key in kwargs.keys()]))
@@ -87,14 +88,23 @@ class BilevelActorCriticAttention(nn.Module):
 
         activation = get_activation(activation)
 
-        encoder_type = kwargs['encoder_type']
+        encoder_type = encoder_type #kwargs['encoder_type']
         encoder_hidden_dims = kwargs['encoder_hidden_dims']
-
+        num_ego_obs = kwargs['num_ego_obs']
+        num_ado_obs = kwargs['num_ado_obs']
+        
+        encodername = 'EncoderAttention' + encoder_type[-1]
+        encoder =  eval(encodername)(num_ego_obs=num_ego_obs, 
+                                    num_ado_obs=num_ado_obs, 
+                                    hidden_dims=kwargs['encoder_hidden_dims'], 
+                                    output_dim=num_ado_obs, 
+                                    numteams=kwargs['numteams'], 
+                                    teamsize=kwargs['teamsize'],
+                                    activation=activation)
         # teamsize = kwargs['teamsize']
         # numteams = kwargs['numteams']
 
-        num_ego_obs = kwargs['num_ego_obs']
-        num_ado_obs = kwargs['num_ado_obs']
+        
 
         self.n_critics = kwargs['numcritics']
         self.is_attentive = kwargs['attentive']

--- a/rsl_rl/modules/bima_actor_critic.py
+++ b/rsl_rl/modules/bima_actor_critic.py
@@ -54,6 +54,7 @@ class MultiTeamBilevelActorCritic(nn.Module):
                         critic_hidden_dims=[256, 256, 256],
                         activation='elu',
                         init_noise_std=1.0,
+                        encoder_type = 'attention4',
                         **kwargs):
 
         super(MultiTeamBilevelActorCritic, self).__init__()
@@ -91,6 +92,7 @@ class MultiTeamBilevelActorCritic(nn.Module):
                                        activation='elu',
                                        init_noise_std=init_noise_std,
                                        team_size=self.team_size,
+                                       encoder_type = encoder_type,
                                        **kwargs) for idx in range(self.num_teams)]
 
         self.agentratings = []
@@ -295,6 +297,7 @@ class TeamBilevelActorCritic(nn.Module):
                         critic_output_dim=1,
                         activation='elu',
                         init_noise_std=1.0,
+                        encoder_type = 'attention4',
                         **kwargs):
         
         super(TeamBilevelActorCritic, self).__init__()
@@ -331,6 +334,7 @@ class TeamBilevelActorCritic(nn.Module):
                                     activation=activation,
                                     init_noise_std=init_noise_std,
                                     critic_output_dim=critic_output_dim,
+                                    encoder_type = encoder_type,
                                     **kwargs)
 
     def reset(self, dones=None):

--- a/rsl_rl/runners/bima_on_policy_runner.py
+++ b/rsl_rl/runners/bima_on_policy_runner.py
@@ -93,14 +93,15 @@ class BimaOnPolicyRunner:
         # num_ego_obs = self.policy_cfg['num_ego_obs']
         # num_ado_obs = self.policy_cfg['num_ado_obs']
 
-        encoder = get_encoder(
-            num_ego_obs=self.policy_cfg['num_ego_obs'], 
-            num_ado_obs=self.policy_cfg['num_ado_obs'], 
-            hidden_dims=encoder_hidden_dims, 
-            teamsize=teamsize,
-            numteams=numteams,
-            device=device,
-        )
+        encoder = None 
+        #get_encoder(
+        #     num_ego_obs=self.policy_cfg['num_ego_obs'], 
+        #     num_ado_obs=self.policy_cfg['num_ado_obs'], 
+        #     hidden_dims=encoder_hidden_dims, 
+        #     teamsize=teamsize,
+        #     numteams=numteams,
+        #     device=device,
+        # )
 
         actor_critic_class_hl = eval(self.cfg["policy_class_hl_name"]) # BilevelActorCritic
         actor_critic_hl: MultiTeamBilevelActorCritic = actor_critic_class_hl(


### PR DESCRIPTION
Changed around the way the encoder is passed to the ac, and registered the team ids as constant torch.nn.buffers such that .to(device) is no longer needed 